### PR TITLE
Capture scroll event in IE < 9

### DIFF
--- a/stickUp.js
+++ b/stickUp.js
@@ -65,7 +65,7 @@ function($) {
 			vartop = parseInt($(this).offset().top);
 			//$(this).find('*').removeClass(itemHover);
 		}
-		$(document).on('scroll', function() {
+		$(window).on('scroll', function() {
 			varscroll = parseInt($(document).scrollTop());
 			if(menuSize != null){
 				for(var i=0;i < menuSize;i++)


### PR DESCRIPTION
A scroll event cannot be captured on the document in IE < 9 ([reference](http://www.quirksmode.org/dom/events/scroll.html)). The window's scroll event will be captured instead to allow the plugin to work in these versions.
